### PR TITLE
maybe bug

### DIFF
--- a/src/sim.cpp
+++ b/src/sim.cpp
@@ -181,9 +181,6 @@ static void initWorld(Engine &ctx)
     ctx.get<Done>(n) = {
       .done = 0
     };
-
-    FullObservation &all_obs = ctx.get<FullObservation>(n);
-    memset(&all_obs, 0, sizeof(FullObservation));
   }
 
   ctx.singleton<WorldReset>().reset = 0;
@@ -736,6 +733,13 @@ inline void matchSystem(Engine &ctx,
         if (best_trade_idx == -1) {
           OrderInfo &glob_bid = world_state.getHighestBid();
 
+          if (glob_bid.issuer == Entity::none()) {
+            printf("[Match Global] Agent %d's bid is not in the book\n", i_agent_idx);
+            break;
+          }
+
+          printf("[DEBUG] Issuer of glob_bid is %d, none entity is %d\n", glob_bid.issuer.id, Entity::none().id);
+
           PlayerState &issuer_state = ctx.get<PlayerState>(glob_bid.issuer);
 
           printf("[Match Global] Agent %d bidding with agent %d's ask of (price = %d; size = %d) from global book\n",
@@ -765,6 +769,11 @@ inline void matchSystem(Engine &ctx,
 
         if (best_trade_idx == -1) {
           OrderInfo &glob_ask = world_state.getLowestAsk();
+
+          if (glob_ask.issuer == Entity::none()) {
+            printf("[Match Global] Agent %d's ask is not in the book\n", i_agent_idx);
+            break;
+          }
 
           PlayerState &issuer_state = ctx.get<PlayerState>(glob_ask.issuer);
 

--- a/train.sh
+++ b/train.sh
@@ -9,14 +9,14 @@ rm -rf ${REPO_DIR}/ckpts/$1
 
 #
 #
-#MADRONA_MWGPU_FORCE_DEBUG=1 MAD_TRADE_DEBUG_WAIT=1 \
+MADRONA_MWGPU_FORCE_DEBUG=1 MAD_TRADE_DEBUG_WAIT=1 \
 XLA_PYTHON_CLIENT_PREALLOCATE=false MADRONA_LEARN_DUMP_LOWERED=/tmp/lowered MADRONA_LEARN_DUMP_IR=/tmp/ir MADRONA_MWGPU_KERNEL_CACHE="${REPO_DIR}/build/cache" \
   python "${REPO_DIR}/scripts/jax_train.py" \
     --ckpt-dir ${REPO_DIR}/ckpts/ \
     --tb-dir "${REPO_DIR}/tb" \
     --run-name $1 \
     --num-updates 1000000 \
-    --num-worlds 4096 \
+    --num-worlds 1 \
     --num-agents 4 \
     --num-npcs 1 \
     --settlement-price 100 \


### PR DESCRIPTION
This was executed using the commands Brennan mentioned to get GDB running:
1. Uncomment the thing inside `train.sh`
2. Run it using `bash train.sh simple run`
3. In another terminal, run `nvidia-smi` and find the PID of the python process
4. Run `sudo cuda-gdb` or `suda $(which cuda-gdb)` and then run `attach [pid]` inside gdb
5. Go up a few times until you get to `mgr` and run `set var done=1`, then run `continue` until it crashes.

GDB output. The world state says there are 2 bids and 2 asks in the global book, and the offsets are currently zero meaning they are still there. However, when we get the highest bid, the issuer ID seems to be 7. We do not know if this is an actual user or not because we're not really able to print the user IDs out. However, we do know that this user does not exist and fails the assert.

```
warning: Cuda API error detected: cuModuleGetGlobal_v2 returned (0x1f4)


Assertion failed.

Thread 1 "python" received signal CUDA_EXCEPTION_12, Warp Assert.
[Switching focus to CUDA kernel 1, grid 8, block (87,0,0), thread (0,0,0), device 0, sm 47, warp 1, lane 0]
0x00007652ad367fb0 in madrona::StateManager::getUnsafe<madtrade::PlayerState> (this=0x0, loc=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/state.inl:307
307         assert(col_idx.has_value());
(cuda-gdb) up
#1  0x00007652ad366b40 in madrona::StateManager::getUnsafe<madtrade::PlayerState> (
    this=0x765290000080, e=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/state.inl:298
298         return getUnsafe<ComponentT>(slot.loc);
(cuda-gdb) 
#2  0x00007652ad365650 in madrona::Context::get<madtrade::PlayerState> (this=0x7652cbfff748, 
    e=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/context.inl:59
59          return mwGPU::getStateManager()->getUnsafe<ComponentT>(e);
(cuda-gdb) 
#3  0x00007652ad2b4940 in madtrade::matchSystem (ctx=..., market=...)
    at /home/madrona/madtrade/src/sim.cpp:743
743               PlayerState &issuer_state = ctx.get<PlayerState>(glob_bid.issuer);

(cuda-gdb) down
#2  0x00007652ad365650 in madrona::Context::get<madtrade::PlayerState> (this=0x7652cbfff748, 
    e=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/context.inl:59
59          return mwGPU::getStateManager()->getUnsafe<ComponentT>(e);
(cuda-gdb) p e
$3 = {gen = 0, id = 7}

(cuda-gdb) up
#3  0x00007652ad2b4940 in madtrade::matchSystem (ctx=..., market=...)
    at /home/madrona/madtrade/src/sim.cpp:743
743               PlayerState &issuer_state = ctx.get<PlayerState>(glob_bid.issuer);

(cuda-gdb) p world_state
$4 = {numPlayerOrders = 4, playerOrders = 0x368e000000, numNPCOrders = 0, 
  npcOrders = 0x769e000000, numPlayers = 4, playerStates = 0x361e000000, numNPCs = 0, 
  npcStates = 0x7614000000, globalBook = {numAsks = 2, asks = 0x6dea000000, 
    askHandles = 0x65ea000000, numBids = 2, bids = 0x5dea000000, bidHandles = 0x55ea000000, 
    curAskOffset = 0, curBidOffset = 0, dummyAsk = {price = 4294967295, size = 0, issuer = {
        gen = 4294967295, id = -1}}, dummyBid = {price = 0, size = 0, issuer = {
        gen = 4294967295, id = -1}}}, stepStats = {volume = 0, dirVolume = 0, 
    totalDollarsTraded = 0, executedTrades = {{size = 0, price = 0}, {size = 0, price = 0}, {
        size = 0, price = 0}, {size = 0, price = 0}, {size = 0, price = 0}}, 
    numExecutedTrades = 0}}

(cuda-gdb) p world_state.numPlayerOrders
Error: read_generic_memory(0, 47, 1, 0): failed to read generic memory at 0xfff488, error=CUDBG_ERROR_INVALID_MEMORY_ACCESS, error message=

(cuda-gdb) p world_state.globalBook
Error: read_generic_memory(0, 47, 1, 0): failed to read generic memory at 0xfff4c8, error=CUDBG_ERROR_INVALID_MEMORY_ACCESS, error message=

(cuda-gdb) down
#2  0x00007652ad365650 in madrona::Context::get<madtrade::PlayerState> (this=0x7652cbfff748, 
    e=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/context.inl:59
59          return mwGPU::getStateManager()->getUnsafe<ComponentT>(e);
(cuda-gdb) p e
$10 = {gen = 0, id = 7}

(cuda-gdb) up
#3  0x00007652ad2b4940 in madtrade::matchSystem (ctx=..., market=...)
    at /home/madrona/madtrade/src/sim.cpp:743
743               PlayerState &issuer_state = ctx.get<PlayerState>(glob_bid.issuer);
(cuda-gdb) p glob_bid.issuer
Unknown storage specifier (read) 0x10000
(cuda-gdb) p glob_bid
$11 = (@register _ZN8madtrade9OrderInfoE & @register) <error reading variable: Unknown storage specifier (read) 0x10000>

(cuda-gdb) down
#2  0x00007652ad365650 in madrona::Context::get<madtrade::PlayerState> (this=0x7652cbfff748, 
    e=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/context.inl:59
59          return mwGPU::getStateManager()->getUnsafe<ComponentT>(e);
(cuda-gdb) down
#1  0x00007652ad366b40 in madrona::StateManager::getUnsafe<madtrade::PlayerState> (
    this=0x765290000080, e=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/state.inl:298
298         return getUnsafe<ComponentT>(slot.loc);

(cuda-gdb) p e
$12 = {gen = 0, id = 7}

(cuda-gdb) down
#0  0x00007652ad367fb0 in madrona::StateManager::getUnsafe<madtrade::PlayerState> (this=0x0, 
    loc=...)
    at /home/madrona/madtrade/external/madrona/src/mw/device/include/madrona/state.inl:307
307         assert(col_idx.has_value());

(cuda-gdb) p loc
$14 = {archetype = 4, row = 0}

(cuda-gdb) down
Bottom (innermost) frame selected; you cannot go down.

(cuda-gdb) p col_idx
$15 = {{empty_ = {<No data fields>}, value_ = 0}, initialized_ = false}

(cuda-gdb) p archetype
$16 = (@register _ZN7madrona12StateManager14ArchetypeStoreE & @register) <error reading variable: Unknown storage specifier (read) 0x10000>

(cuda-gdb) p component_id
$17 = 0

(cuda-gdb) p col_idx
$18 = {{empty_ = {<No data fields>}, value_ = 0}, initialized_ = false}
```